### PR TITLE
Prevent WebSocket error in web3 1.0.0-beta.34

### DIFF
--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -20,8 +20,8 @@
     "promisify-node-callback": "^1.0.2",
     "sockjs-client": "1.0.3",
     "uport-connect": "^0.7.3",
-    "web3": "1.0.0-beta.34",
+    "web3": "1.0.0-beta.33",
     "webstomp-client": "^1.2.0",
-    "web3-eth-accounts": "^1.0.0-beta.34"
+    "web3-eth-accounts": "^1.0.0-beta.33"
   }
 }


### PR DESCRIPTION
Downgraded to 1.0.0-beta.33

See https://github.com/ethereum/web3.js/issues/1559